### PR TITLE
Add Cleatext HTTP Traffic

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     package="com.ciderapp.webremote">
    <application
         android:label="Cider Remote"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"


### PR DESCRIPTION
Since Android 9, Cleartext defaults to false, change to true.
https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic