### PR TITLE
Added `Go back` button to the QR Scan Screen

### DIFF
--- a/lib/qrview.dart
+++ b/lib/qrview.dart
@@ -53,6 +53,14 @@ class _QRViewScreen extends State<QRViewScreen> {
           )
         ],
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          Navigator.pop(context);
+        },
+        label: const Text('Go back'),
+        backgroundColor: Colors.pink,
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );
   }
 


### PR DESCRIPTION
On iOS, you either have to force close the app to stop the camera or swipe right (which most people don't know about-) in the app to return to the `Scanning for Cider Instance` Screen which can be annoying. This update adds a `Go back` button to the bottom centre of the screen to fix the same.

Thank you!